### PR TITLE
Add support for CData 

### DIFF
--- a/packages/lwdita-ast/src/ast-utils.ts
+++ b/packages/lwdita-ast/src/ast-utils.ts
@@ -29,9 +29,9 @@ const phGroup = ['b', 'em', 'i', 'ph', 'strong', 'sub', 'sup', 'tt', 'u'];
  */
 export const nodeGroups: Record<string, Array<string>> = {
     'ph': phGroup,
-    'inline.noimage': ['text', ...phGroup, 'xref'],
-    'inline.noxref': ['text', ...phGroup, 'image'],
-    'inline': ['text', ...phGroup, 'image', 'xref'],
+    'inline.noimage': ['cdata', 'text', ...phGroup, 'xref'],
+    'inline.noxref': ['cdata', 'text', ...phGroup, 'image'],
+    'inline': ['cdata','text', ...phGroup, 'image', 'xref'],
     'simple-blocks': ['p', 'ul', 'ol', 'dl', 'pre', 'audio', 'video', 'example', 'note'],
     'fn-blocks': ['p', 'ul', 'ol', 'dl'],
     'all-blocks': ['p','ul','ol','dl','pre','audio','video','example','simpletable','fig','note'],

--- a/packages/lwdita-ast/src/nodes/cdata.ts
+++ b/packages/lwdita-ast/src/nodes/cdata.ts
@@ -1,0 +1,104 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { AbstractBaseNode, BaseNode, makeComponent } from "./base";
+import { isOrUndefined } from "../utils";
+import { JDita } from "../ast-classes";
+import { BasicValue } from "../classes";
+
+/**
+ * The valid fields for the CDataNode.
+ */
+export const CDataFields = ['content'];
+
+/**
+ * Interface CDataNodeAttributes defines the attributes for the CDataNode.
+ */
+export interface CDataNodeAttributes extends BaseNode {
+  'content'?: string
+}
+
+/**
+ * Check if the attribute `content` of the `CDataNode` is valid.
+ *
+ * @param field - The name of the attribute.
+ * @param value - The value of the attribute.
+ * @returns A boolean indicating if the attribute is valid.
+ */
+export function isValidCDataField(field: string, value: BasicValue): boolean {
+  switch (field) {
+    case 'content': return isOrUndefined(content => typeof content === 'string', value);
+    default: return false;
+  }
+}
+
+/**
+ * Check if the `CDataNode` is valid.
+ *
+ * @remarks
+ * Assert that the CDataNode is an object, has content,
+ * and that the content is of type `string`.
+ *
+ * @param value - The CDataNode to test.
+ * @returns A boolean indicating if the CDataNode is valid.
+ */
+export const isCDataNode = (value?: unknown): value is CDataNodeAttributes =>
+  typeof value === 'object' && !!value && 'content' in value && typeof value.content === 'string';
+
+/**
+ * Construct a `CDataNode` containing a `content` property.
+ *
+ * @param constructor - The constructor.
+ * @returns The `CDataNode`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function makeCData<T extends { new(...args: any[]): AbstractBaseNode }>(constructor: T): T {
+  return class extends constructor implements CDataNode {
+    get 'content'(): string {
+      return this.readProp('content');
+    }
+    set 'content'(value: string) {
+      this.writeProp('content', value);
+    }
+  }
+}
+
+/**
+ * Create a `CDataNode` containing a text content.
+ *
+ * @decorator `@makeComponent`
+ * @param makeCData - The `CDataNode` constructor.
+ * @param nodeName - The name of the node.
+ * @param isValidTextField - A boolean value indicating if the attribute is valid or not.
+ * @param fields - The valid attribute `content` of type string.
+ */
+@makeComponent(makeCData, 'cdata', isValidCDataField, CDataFields)
+export class CDataNode extends AbstractBaseNode implements CDataNodeAttributes {
+
+  // CDataNodeAttributes {
+  'content'?: string
+
+  constructor(content: string) {
+    super({ content });
+  }
+  get json(): JDita {
+    return {
+      nodeName: this.static.nodeName,
+      content: this._props['content'] as string,
+    };
+  }
+}

--- a/packages/lwdita-ast/src/nodes/index.ts
+++ b/packages/lwdita-ast/src/nodes/index.ts
@@ -21,6 +21,7 @@ export * from './base';
 export * from './body';
 export * from './bold';
 export * from './class';
+export * from './cdata';
 export * from './dd';
 export * from './desc';
 export * from './display';

--- a/packages/lwdita-ast/src/nodes/pre.ts
+++ b/packages/lwdita-ast/src/nodes/pre.ts
@@ -103,7 +103,7 @@ export function makePre<T extends { new(...args: any[]): AbstractBaseNode }>(con
  * @param fields - A List of valid attributes @See {@link PreFields}
  * @param childNodes - An Array of allowed child nodes `text*`, `%ph*`, `xref*`, `%data*`
  */
-@makeComponent(makePre, 'pre', isValidPreField, PreFields, [['text*', '%ph*', 'xref*']])
+@makeComponent(makePre, 'pre', isValidPreField, PreFields, [['text*', '%ph*', 'xref*', '%cdata*']])
 export class PreNode extends AbstractBaseNode implements PreNodeAttributes {
   static domNodeName = 'pre';
 

--- a/packages/lwdita-ast/src/nodes/pre.ts
+++ b/packages/lwdita-ast/src/nodes/pre.ts
@@ -103,7 +103,7 @@ export function makePre<T extends { new(...args: any[]): AbstractBaseNode }>(con
  * @param fields - A List of valid attributes @See {@link PreFields}
  * @param childNodes - An Array of allowed child nodes `text*`, `%ph*`, `xref*`, `%data*`
  */
-@makeComponent(makePre, 'pre', isValidPreField, PreFields, [['text*', '%ph*', 'xref*', '%cdata*']])
+@makeComponent(makePre, 'pre', isValidPreField, PreFields, [['text*', '%ph*', 'xref*', 'cdata*']])
 export class PreNode extends AbstractBaseNode implements PreNodeAttributes {
   static domNodeName = 'pre';
 

--- a/packages/lwdita-ast/test/pre.spec.ts
+++ b/packages/lwdita-ast/test/pre.spec.ts
@@ -24,7 +24,7 @@ doNodeTest(
   'pre',
   isPreNode,
   ['xml:space', 'dir', 'xml:lang', 'translate', 'props', 'id', 'conref', 'outputclass', 'class'],
-  ['(text|%ph|xref)*']
+  ['(text|%ph|xref|cdata)*']
 );
 
 describe('Class PreNode', () => {

--- a/packages/lwdita-xdita/src/converter.ts
+++ b/packages/lwdita-xdita/src/converter.ts
@@ -107,11 +107,11 @@ export async function xditaToAst(xml: string, abortOnError = true): Promise<Docu
       stack.pop();
     });
 
+    // Look for CDATA and add the node to the array
     parser.on("cdata", (cdata) => {
-      try {        
+      try {
         const obj = createCDataSectionNode(cdata);
         stack[stack.length - 1].add(obj, abortOnError);
-
       } catch (e) {
         console.log('invalid:', e);
       }
@@ -148,7 +148,7 @@ export async function xditaToJdita(xml: string, abortOnError = true): Promise<JD
 
 /**
  * Convert the document node to JDita object
- * 
+ *
  * @param document - DocumentNode
  * @returns JDita object
  */

--- a/packages/lwdita-xdita/src/converter.ts
+++ b/packages/lwdita-xdita/src/converter.ts
@@ -16,10 +16,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import * as saxes from "@rubensworks/saxes";
-import { BaseNode, DocumentNode } from "@evolvedbinary/lwdita-ast";
-import { createNode } from "./factory";
+import { BaseNode, DocumentNode, JDita } from "@evolvedbinary/lwdita-ast";
+import { createCDataSectionNode, createNode } from "./factory";
 import { InMemoryTextSimpleOutputStreamCollector } from "./stream";
-import { JDita } from "@evolvedbinary/lwdita-ast";
 import { XditaSerializer } from "./xdita-serializer";
 
 /** TODO: Add tests for this module */
@@ -63,7 +62,6 @@ export async function xditaToAst(xml: string, abortOnError = true): Promise<Docu
       if (wsRegEx.test(text) && !parentNode.canAdd(node)) {
         return;
       }
-
       // add the text node to the parent
       stack[stack.length - 1].add(node, abortOnError);
     });
@@ -108,6 +106,16 @@ export async function xditaToAst(xml: string, abortOnError = true): Promise<Docu
     parser.on("closetag", function () {
       stack.pop();
     });
+
+    parser.on("cdata", (cdata) => {
+      try {        
+        const obj = createCDataSectionNode(cdata);
+        stack[stack.length - 1].add(obj, abortOnError);
+
+      } catch (e) {
+        console.log('invalid:', e);
+      }
+    })
 
     // return the document tree if run without errors
     parser.on("end", function () {

--- a/packages/lwdita-xdita/src/factory.ts
+++ b/packages/lwdita-xdita/src/factory.ts
@@ -22,6 +22,7 @@ import { AltNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { AudioNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { BodyNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { BoldNodeAttributes } from "@evolvedbinary/lwdita-ast";
+import { CDataNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { DescNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { DivNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { DdNodeAttributes } from "@evolvedbinary/lwdita-ast";
@@ -39,6 +40,7 @@ import { KeydefNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { KeytextNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { LiNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { MapNodeAttributes } from "@evolvedbinary/lwdita-ast";
+import { CDataNode } from "@evolvedbinary/lwdita-ast";
 import { MediaSourceNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { MediaTrackNodeAttributes } from "@evolvedbinary/lwdita-ast";
 import { MetadataNodeAttributes } from "@evolvedbinary/lwdita-ast";
@@ -166,4 +168,8 @@ export function createNode<T extends AbstractBaseNode>(node: XMLNode | string): 
     return new classType(node.attributes) as T;
   }
   return nodeObject as T;
+}
+
+export function createCDataSectionNode(cdata: string): CDataNodeAttributes {
+  return new CDataNode(cdata);
 }

--- a/packages/lwdita-xdita/src/jdita-serializer.ts
+++ b/packages/lwdita-xdita/src/jdita-serializer.ts
@@ -137,6 +137,11 @@ export class JditaSerializer {
           this.outputStream.emit(String(jdita.content));
         }
 
+      } else if (jdita.nodeName === "cdata") {
+        // if the node is a cdata node, serialize its content and wrap it with the cdata
+        const cdataOpen = `<![CDATA[`;
+        const cdataClose = `]]>`;
+        this.outputStream.emit(cdataOpen + String(jdita.content) + cdataClose);
       } else {
         this.serializeJDitaElement(jdita);
       }

--- a/packages/lwdita-xdita/src/xdita-serializer.ts
+++ b/packages/lwdita-xdita/src/xdita-serializer.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { AbstractBaseNode, DocumentNode, TextNode } from "@evolvedbinary/lwdita-ast";
+import { AbstractBaseNode, CDataNode, DocumentNode, TextNode } from "@evolvedbinary/lwdita-ast";
 import { TextSimpleOutputStream } from "./stream";
 
 /**
@@ -136,6 +136,20 @@ export class XditaSerializer {
   }
 
   /**
+   * Serialize the content of cdata to the output stream
+   *
+   * @param node - the node to serialize the content of
+   */
+    private serializeCData(node: TextNode): void {
+      const props = node.getProps();
+      if (props['content']) {
+        const cdataOpen = `<![CDATA[`;
+        const cdataClose = `]]>`;
+        this.outputStream.emit(cdataOpen + String(props['content']) + cdataClose);
+      }
+    }
+
+  /**
    * Visit a node and serialize it to the output stream
    *
    * @param node - the node to serialize
@@ -153,6 +167,10 @@ export class XditaSerializer {
       if (node instanceof TextNode) {
         // if the node is a text node, serialize its text content
         this.serializeText(node);
+
+      } else if (node instanceof CDataNode) {
+        // if the node is a text node, serialize its text content
+        this.serializeCData(node);
 
       } else {
         // TODO(AR) ideally we should have `node instanceof ElementNode` type guard here

--- a/packages/lwdita-xdita/test/jdita-serializer.spec.ts
+++ b/packages/lwdita-xdita/test/jdita-serializer.spec.ts
@@ -19,7 +19,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import { expect } from 'chai';
 import { JditaSerializer } from '../src/jdita-serializer';
 import { InMemoryTextSimpleOutputStreamCollector } from '../src/stream';
-import { DocumentNode, TextNode, TitleNode, TopicNode } from "@evolvedbinary/lwdita-ast"
+import { CDataNode, DocumentNode, TextNode, TitleNode, TopicNode } from "@evolvedbinary/lwdita-ast"
+import { xditaToJdita } from '../src/converter';
 
 describe('jditaSerializer', () => {
   let outStream: InMemoryTextSimpleOutputStreamCollector;
@@ -103,4 +104,39 @@ describe('jditaSerializer', () => {
     expect(outStream.getText()).equal('<topic><title dir="ltr" class="title"/></topic>');
   });
 
+  it('serialize a document with cdata', () => {
+    // test setup
+    const document = new DocumentNode();
+    const topic = new TopicNode();
+    document.add(topic);
+    const title = new TitleNode();
+    const cdata = new CDataNode('cdata');
+    title.add(cdata);
+    topic.add(title);
+
+    const jdita = document.json
+
+    // perform serialization
+    serializer.serializeFromJdita(jdita);
+
+    // expect the output stream to contain the correct XML with attributes
+    expect(outStream.getText()).equal('<topic><title><![CDATA[cdata]]></title></topic>');
+  });
+});
+
+describe('complete round trip using jdita serializer', () => {
+  it('round trip from xdita and back with cdata', async () => {
+
+    const orginalXdita = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd"><topic><title><![CDATA[cdata]]></title></topic>`
+    
+    const orginalAst = await xditaToJdita(orginalXdita);
+    // perform serialization
+    const outStream = new InMemoryTextSimpleOutputStreamCollector();
+    const serializer = new JditaSerializer(outStream);
+    serializer.serializeFromJdita(orginalAst);
+
+    const xdita = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">` + outStream.getText();
+
+    expect(orginalXdita).deep.equal(xdita);
+  });
 });


### PR DESCRIPTION
This PR will add support for CDATA tags 
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
<topic>
    <title><![CDATA[cdata]]></title>
</topic>
```
It will be added to document node now
```ts
{
  "nodeName": "document",
  "children": [
    {
      "nodeName": "topic",
      "attributes": {},
      "children": [
        {
          "nodeName": "title",
          "attributes": {},
          "children": [
            {
              "nodeName": "cdata",
              "content": "cdata"
            }
          ]
        }
      ]
    }
  ]
}
```
Also the CData support was added to the serializer.