### PR TITLE
Enable handling of XML declaration and doctype

### DIFF
--- a/packages/lwdita-ast/src/nodes/document.ts
+++ b/packages/lwdita-ast/src/nodes/document.ts
@@ -22,6 +22,15 @@ import { stringToChildTypes } from "../utils";
  * Interface DocumentNode defines the attribute types for a document node.
  */
 export interface DocumentNodeAttributes {}
+// XML declaration interface
+export interface XMLDecl {
+  /** The version specified by the XML declaration. */
+  version?: string;
+  /** The encoding specified by the XML declaration. */
+  encoding?: string;
+  /** The value of the standalone parameter */
+  standalone?: string;
+}
 
 /**
  * The `document` node is the root node of the document tree and the entry point for the parser
@@ -39,5 +48,7 @@ export class DocumentNode extends AbstractBaseNode implements DocumentNodeAttrib
   static childTypes = stringToChildTypes(['topic']);
   static fields = [];
   static isValidField = (): boolean => true;
+  xmlDecl: XMLDecl | undefined;
+  doctype: string | undefined;
 
 }

--- a/packages/lwdita-xdita/src/converter.ts
+++ b/packages/lwdita-xdita/src/converter.ts
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import * as saxes from "@rubensworks/saxes";
 import { createCDataSectionNode, createNode } from "./factory";
-import { Attributes, BasicValue, TextNode, getNodeClass, JDita, BaseNode, DocumentNode, CDataNode } from "@evolvedbinary/lwdita-ast";
+import { Attributes, BasicValue, TextNode, getNodeClass, JDita, BaseNode, DocumentNode, CDataNode, AbstractBaseNode } from "@evolvedbinary/lwdita-ast";
 import { InMemoryTextSimpleOutputStreamCollector } from "./stream";
 import { XditaSerializer } from "./xdita-serializer";
 
@@ -46,6 +46,15 @@ export async function xditaToAst(xml: string, abortOnError = true): Promise<Docu
 
     // Create an array of Document nodes (type BaseNode)
     const stack: BaseNode[] = [doc];
+
+    // Look for the XML declaration and the DOCTYPE declaration
+    parser.on("xmldecl", function (xmlDecl) {
+
+      doc.xmlDecl = xmlDecl;
+    });
+    parser.on("doctype", function (doctype) {
+      doc.doctype = doctype;
+    });
 
     // Parse the text and add a new node item to the node-array
     // `text` is the content of any text node in the parsed xml document
@@ -187,7 +196,7 @@ function jditaAttrToSaxesAttr(attr: Record<string, BasicValue> | undefined): Att
  * @param jdita - JDita object
  * @returns DocumentNode
  */
-export function jditaToAst(jdita: JDita): DocumentNode {
+export function jditaToAst(jdita: JDita): AbstractBaseNode {
   if(jdita.nodeName === 'document') {
     const doc = new DocumentNode();
     jdita.children?.forEach(child => {

--- a/packages/lwdita-xdita/src/xdita-serializer.ts
+++ b/packages/lwdita-xdita/src/xdita-serializer.ts
@@ -78,8 +78,8 @@ export class XditaSerializer {
    */
   private serializeDocument(node: DocumentNode): void {
     // emit the XML declaration and doctype declaration
-    const xmlDeclaration = `<?xml version="1.0" encoding="UTF-8"?>`;
-    const docTypeDeclaration = `<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">`;
+    const xmlDeclaration = `<?xml version="${node.xmlDecl?.version || "1.0"}" encoding="${node.xmlDecl?.encoding || "UTF-8"}"?>`;
+    const docTypeDeclaration = `<!DOCTYPE${node.doctype || ' topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd"'}>`;
 
     this.outputStream.emit(xmlDeclaration);
     this.outputStream.emit(this.EOL);

--- a/packages/lwdita-xdita/test/xdita-serializer.spec.ts
+++ b/packages/lwdita-xdita/test/xdita-serializer.spec.ts
@@ -258,3 +258,53 @@ describe('complete round trip using xdita serializer', () => {
       });
   });
 });
+
+describe('handles custom xml declaration and doctype', () => {
+  it('should read and output custom xml version', async () => {
+    const { serializer, outStream } = newSerializer(false);
+
+    const input = '<?xml version="1.6" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n<topic><title>Hello World</title><body><p>Good\nMorning</p></body></topic>'
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+
+    const declaration = `<?xml version="1.6" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n`;
+    const expected = declaration + "<topic><title>Hello World</title><body><p>Good\nMorning</p></body></topic>"
+
+    const actual = outStream.getText()
+    // expect the output stream to contain the correct XML with attributes
+    expect(actual).equal(expected);
+  })
+
+  it('should read and output custom doctype', async () => {
+    const { serializer, outStream } = newSerializer(false);
+
+    const input = '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE Some random declaration for testing>\n<topic><title>Hello World</title><body><p>Good\nMorning</p></body></topic>'
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+
+    const declaration = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE Some random declaration for testing>\n`;
+    const expected = declaration + "<topic><title>Hello World</title><body><p>Good\nMorning</p></body></topic>"
+
+    const actual = outStream.getText()
+    // expect the output stream to contain the correct XML with attributes
+    expect(actual).equal(expected);
+  })
+
+  it('should output the default if nothing was provided', async () => {
+    const { serializer, outStream } = newSerializer(false);
+
+    const input = '<topic><title>Hello World</title><body><p>Good\nMorning</p></body></topic>'
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+
+    const declaration = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n`;
+    const expected = declaration + "<topic><title>Hello World</title><body><p>Good\nMorning</p></body></topic>"
+
+    const actual = outStream.getText()
+    // expect the output stream to contain the correct XML with attributes
+    expect(actual).equal(expected);
+  })
+})


### PR DESCRIPTION
The parser will now pull the XMl declaration and doctype from the document and out them in the serializer instead of the using static strings.
in case nothing was provided a default xml declaration and doctype will be used 
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
```

How to test this PR:
* check tests on 16487195e290221467ea1ef1e8572951d431a5f4
* run the tests.