### PR TITLE
Revert temp workaround for the mixed content condition

### DIFF
--- a/packages/lwdita-ast/src/nodes/base.ts
+++ b/packages/lwdita-ast/src/nodes/base.ts
@@ -295,7 +295,9 @@ export abstract class AbstractBaseNode implements BaseNode {
   }
 
   allowsMixedContent(): boolean {
-    return this.canAdd("text");
+    //This is a temporary solution REMOVE the alt node as it's not mixed content
+    // by YB, signed-off by AR.
+    return this.canAdd("text") || this.canAdd("alt");
   }
 }
 

--- a/packages/lwdita-xdita/src/xdita-serializer.ts
+++ b/packages/lwdita-xdita/src/xdita-serializer.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { AbstractBaseNode, AltNode, CDataNode, DocumentNode, TextNode } from "@evolvedbinary/lwdita-ast";
+import { AbstractBaseNode, CDataNode, DocumentNode, TextNode } from "@evolvedbinary/lwdita-ast";
 import { TextSimpleOutputStream } from "./stream";
 
 /**
@@ -49,15 +49,6 @@ export class XditaSerializer {
     this.EOL = '\n';
   }
 
-  // Temporary fix for the serializer of images and fallback nodes see:
-  // https://evolvedbinaryltd.kanbanize.com/ctrl_board/16/cards/3516/details/
-  private serializeMixedContent(node: AbstractBaseNode) {
-    //This is a temporary solution REMOVE the alt node as it's not mixed content
-    // by YB, signed-off by AR.
-    const alt = new AltNode();
-    return node.allowsMixedContent() || node.canAddNode(alt);
-  }
-
   /**
    * Emit the indentation to the output stream
    * 
@@ -65,7 +56,7 @@ export class XditaSerializer {
    */
   private serializeIndentation(node?: AbstractBaseNode): void {
     if (!this.indent || !node) return;
-    if (this.serializeMixedContent(node)) return;
+    if (node.allowsMixedContent()) return;
     this.outputStream.emit(this.indentation.repeat(this.depth * this.tabSize));
   }
 
@@ -76,7 +67,7 @@ export class XditaSerializer {
    */
   private serializeEOL(node?: AbstractBaseNode): void {
     if (!this.indent || !node) return;
-    if (this.serializeMixedContent(node)) return;
+    if (node.allowsMixedContent()) return;
     this.outputStream.emit(this.EOL);
   }
 


### PR DESCRIPTION
This reverts commit d93c60838023949c0c9456d143cc733f321a133e.
Remove the temporary hack to make the images act like an inline element( allowsMixedContent).
This is no longer need as we aim to conform to the dtd.