### PR TITLE
Create a rank field on all lwdita nodes

### DIFF
--- a/packages/lwdita-ast/src/nodes/base.ts
+++ b/packages/lwdita-ast/src/nodes/base.ts
@@ -128,6 +128,9 @@ export abstract class AbstractBaseNode implements BaseNode {
   // human readable label for the node
   static label?: string;
 
+  // `rank` is for display purposes
+  static rank = 1; // base rank for all nodes
+
   static inline?: boolean;
   // `fields` are attributes of the node eg <node field="value" />
   static fields: Array<string>;

--- a/packages/lwdita-ast/src/nodes/li.ts
+++ b/packages/lwdita-ast/src/nodes/li.ts
@@ -84,6 +84,8 @@ export function makeLi<T extends Constructor>(constructor: T): T {
 export class LiNode extends AbstractBaseNode implements LiNodeAttributes {
   static domNodeName = 'li';
   static label = "List item";
+
+  static rank = 100; // highest rank
   
   // ClassNodeAttributes
   'outputclass'?: CDATA

--- a/packages/lwdita-ast/src/nodes/p.ts
+++ b/packages/lwdita-ast/src/nodes/p.ts
@@ -87,6 +87,9 @@ export function makeP<T extends Constructor>(constructor: T): T {
 export class PNode extends AbstractBaseNode implements PNodeAttributes {
   static domNodeName = 'p';
   static label = "Paragraph";
+
+  static rank = 10; // standard rank for a paragraph
+
   // ClassNodeAttributes
   'outputclass'?: CDATA
   'class'?: CDATA

--- a/packages/lwdita-ast/test/li.spec.ts
+++ b/packages/lwdita-ast/test/li.spec.ts
@@ -50,3 +50,11 @@ describe('Class LiNode', () => {
     expect(li.class).to.equal("class");
   });
 });
+
+describe("Get rank for special node li",() => {
+  it("The rank should be 100 for special node li", () => {
+    const rank = LiNode.rank;
+
+    expect(rank).to.eq(100);
+  });
+});

--- a/packages/lwdita-ast/test/p.spec.ts
+++ b/packages/lwdita-ast/test/p.spec.ts
@@ -48,3 +48,11 @@ describe('Class PNode', () => {
     expect(p.class).to.equal("class");
   });
 });
+
+describe("Get rank for special node p",() => {
+  it("The rank should be 10 for special node p", () => {
+    const rank = PNode.rank;
+    
+    expect(rank).to.eq(10);
+  });
+});

--- a/packages/lwdita-ast/test/section.spec.ts
+++ b/packages/lwdita-ast/test/section.spec.ts
@@ -46,3 +46,11 @@ describe('Class SectionNode', () => {
     expect(section.class).to.equal("class");
   });
 });
+
+describe("Get rank for generic node",() => {
+  it("The rank should be 1 for generic node", () => {
+    const rank = SectionNode.rank;
+  
+    expect(rank).to.eq(1);
+  });
+});


### PR DESCRIPTION
This will create a ranking system, it will allow us to rearrange nodes based on their usage frequency.
The current ranking: base rank that applies to all nodes, and two exceptions. P element with 10, and Li element with 100.
