### PR TITLE
Escape special chars in elements

### DIFF
--- a/packages/lwdita-xdita/src/converter.ts
+++ b/packages/lwdita-xdita/src/converter.ts
@@ -20,6 +20,7 @@ import { createCDataSectionNode, createNode } from "./factory";
 import { Attributes, BasicValue, TextNode, getNodeClass, JDita, BaseNode, DocumentNode, DocTypeDecl, CDataNode, AbstractBaseNode, XMLDecl } from "@evolvedbinary/lwdita-ast";
 import { InMemoryTextSimpleOutputStreamCollector } from "./stream";
 import { XditaSerializer } from "./xdita-serializer";
+import { escapeXMLCharacters } from "./utils";
 
 /**
  * Converts XML to an AST document tree
@@ -63,8 +64,7 @@ export async function xditaToAst(xml: string, abortOnError = true): Promise<Docu
     // `text` is the content of any text node in the parsed xml document
     parser.on("text", function (text) {
       const parentNode = stack[stack.length - 1];
-      const node: BaseNode = createNode(text);
-
+      
       // if the 'text' string is only whitespace characters,
       // and the parent node cannot accept a text node (i.e. it does not support #PCDATA),
       // then the whitespace is non-significant as far as the DTD is concerned... so just discard it!
@@ -72,6 +72,8 @@ export async function xditaToAst(xml: string, abortOnError = true): Promise<Docu
       if (wsRegEx.test(text) && !parentNode.allowsMixedContent()) {
         return;
       }
+
+      const node: BaseNode = createNode(text);
       // add the text node to the parent
       stack[stack.length - 1].add(node, abortOnError);
     });

--- a/packages/lwdita-xdita/src/utils.ts
+++ b/packages/lwdita-xdita/src/utils.ts
@@ -36,3 +36,32 @@ export function storeOutputXML(xml: string, path: string): void {
     fs.writeFileSync(path,xml)
 }
 
+/**
+ * Escape XML characters in a string
+ * 
+ * @param text - The text to escape
+ * @returns - The escaped text
+ */
+export function escapeXMLCharacters(text: string): string {
+    return text.replace(/[&<>]/g, (match) => {
+        switch (match) {
+            case "&": return "&amp;";
+            case "<": return "&lt;";
+            case ">": return "&gt;";
+            default: return match;
+        }
+    })
+}
+
+/**
+ * Escape characters for attribute values
+*/
+export function escapeXMLAttributeCharacters(text: string): string {
+    return text.replace(/[&"]/g, (match) => {
+        switch (match) {
+            case '"': return "&quot;";
+            case "&": return "&amp;";
+            default: return match;
+        }
+    })
+}

--- a/packages/lwdita-xdita/src/xdita-serializer.ts
+++ b/packages/lwdita-xdita/src/xdita-serializer.ts
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { AbstractBaseNode, CDataNode, DocumentNode, TextNode } from "@evolvedbinary/lwdita-ast";
 import { TextSimpleOutputStream } from "./stream";
+import { escapeXMLAttributeCharacters, escapeXMLCharacters } from "./utils";
 
 /**
  * Serializer for XDITA.
@@ -168,7 +169,7 @@ export class XditaSerializer {
     const props = node.getProps();
     if (props) {
       const attr = props as Record<string, string>;
-      attrsStr = Object.keys(props).filter(key => attr[key]).map(key => `${key}="${attr[key]}"`).join(' ');
+      attrsStr = Object.keys(props).filter(key => attr[key]).map(key => `${key}="${escapeXMLAttributeCharacters(attr[key])}"`).join(' ');
     }
     if (attrsStr.length) {
       attrsStr = ` ${attrsStr}`;
@@ -184,7 +185,9 @@ export class XditaSerializer {
   private serializeText(node: TextNode): void {
     const props = node.getProps();
     if (props['content']) {
-      this.outputStream.emit(String(props['content']));
+      let textContent = String(props['content']);
+      textContent = escapeXMLCharacters(textContent);
+      this.outputStream.emit(textContent);
     }
   }
 

--- a/packages/lwdita-xdita/test/converter.spec.ts
+++ b/packages/lwdita-xdita/test/converter.spec.ts
@@ -331,3 +331,52 @@ describe('Round trip with custom doctype and xml declaration', () => {
     });
   });
 });
+
+
+
+describe('Round trip with special chars', () => {
+    it(`round trip with paragapth with special chars`, async () => {
+      const header = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n`
+      const xdita = `<topic id="topicID"><title>t</title><body><p>Escape &lt;special&gt; characters &amp;, &lt;, &gt;.</p></body></topic>`;
+
+      // xdita -> ast
+      const ast = await xditaToAst(header + xdita);
+      
+      // ast -> jdita
+      const jdita = astToJdita(ast);
+
+      // jdita -> ast
+      const newAst = jditaToAst(jdita);
+
+      // ast -> xdita
+      const outStream = new InMemoryTextSimpleOutputStreamCollector();
+      const serializer = new XditaSerializer(outStream);
+      serializer.serialize(newAst);
+      const newXdita = outStream.getText();
+
+      expect(newXdita).to.equal(header + xdita);
+    });
+
+
+    it(`round trip with attributes with special chars`, async () => {
+      const header = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n`
+      const xdita = `<topic id="topicID"><title outputclass="test&amp;test&quot;s">t</title></topic>`;
+
+      // xdita -> ast
+      const ast = await xditaToAst(header + xdita);
+      
+      // ast -> jdita
+      const jdita = astToJdita(ast);
+
+      // jdita -> ast
+      const newAst = jditaToAst(jdita);
+
+      // ast -> xdita
+      const outStream = new InMemoryTextSimpleOutputStreamCollector();
+      const serializer = new XditaSerializer(outStream);
+      serializer.serialize(newAst);
+      const newXdita = outStream.getText();
+
+      expect(newXdita).to.equal(header + xdita);
+    });
+});


### PR DESCRIPTION
# Motivation
`Saxes` parser format the text by default eg
```
---&gt; Save As --&gt;
will be transformed to
---> Save As -->
```
# The fix
Add special chars escaping function 
```ts
export function escapeXMLCharacters(text: string): string {
    return text.replace(/[&<>"']/g, (match) => {
        switch (match) {
            case "&": return "&amp;";
            case "<": return "&lt;";
            case ">": return "&gt;";
            default: return match;
        }
    })
}
```
It will make sure the xml is valid.