### PR TITLE
Special indentation for nodes without text children

### DIFF
--- a/packages/lwdita-ast/src/ast-utils.ts
+++ b/packages/lwdita-ast/src/ast-utils.ts
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * @see {@link https://github.com/oasis-tcs/dita-lwdita/blob/b2985f254746b2614c1b9d6a5e6043f82335506f/org.oasis.xdita/dtd/lw-topic.dtd#L50}
  */
-const phGroup = ['b', 'em', 'i', 'ph', 'strong', 'sub', 'sup', 'tt', 'u'];
+export const phGroup = ['b', 'em', 'i', 'ph', 'strong', 'sub', 'sup', 'tt', 'u'];
 
 /**
  * Content groups

--- a/packages/lwdita-xdita/src/converter.ts
+++ b/packages/lwdita-xdita/src/converter.ts
@@ -20,7 +20,6 @@ import { createCDataSectionNode, createNode } from "./factory";
 import { Attributes, BasicValue, TextNode, getNodeClass, JDita, BaseNode, DocumentNode, DocTypeDecl, CDataNode, AbstractBaseNode, XMLDecl } from "@evolvedbinary/lwdita-ast";
 import { InMemoryTextSimpleOutputStreamCollector } from "./stream";
 import { XditaSerializer } from "./xdita-serializer";
-import { escapeXMLCharacters } from "./utils";
 
 /**
  * Converts XML to an AST document tree
@@ -70,6 +69,11 @@ export async function xditaToAst(xml: string, abortOnError = true): Promise<Docu
       // then the whitespace is non-significant as far as the DTD is concerned... so just discard it!
       // see: https://github.com/evolvedbinary/lwdita/issues/129#issuecomment-2150243338
       if (wsRegEx.test(text) && !parentNode.allowsMixedContent()) {
+        return;
+      }
+
+      // ignore leading/trailing whitespace
+      if(!text.trim()) {
         return;
       }
 

--- a/packages/lwdita-xdita/test/test-utils.ts
+++ b/packages/lwdita-xdita/test/test-utils.ts
@@ -50,21 +50,19 @@ export const XMLNODE_UNKNOWN = `{"name":"unknown","attributes":{},"ns":{},"prefi
 
 export const fullXditaExample = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">
-<topic id="fullTopic"><title dir="ltr" xml:lang="english" translate="no">
-        <b>bold</b> and <em>emphasized</em> and <i>italic</i> and <ph>Phrase content</ph> and <strong>strong</strong>
-        and <sub>subscript</sub> and <sup>superscipt</sup> and <tt>tele type</tt> and <u>underline</u><image/>
-        </title><shortdesc>Short description of the full topic.</shortdesc><prolog props="metadata"><metadata><othermeta name="test" content="test"/></metadata></prolog><body outputclass="outputclass"><p>Paragraph content</p><ul><li><p>Unordered list item</p></li></ul><ol><li><p>Ordered list item</p></li></ol><dl><dlentry><dt>Definition term</dt><dd><p>Definition description</p></dd></dlentry></dl><pre>Preformatted content</pre><audio autoplay="false" controls="true" loop="false" muted="false"><desc>Theme song for the LwDITA podcast</desc><fallback><p>The theme song is not available.</p></fallback><media-source href="theme-song.mp3"/><media-track href="theme-song.vtt" srclang="en"/></audio><video width="400px" height="300px" loop="false" muted="false"><desc>Video about the Sensei Sushi promise.</desc><fallback><image href="video-not-available.png"><alt>This video cannot be displayed.</alt></image></fallback><video-poster href="sensei-video.jpg"/><media-source href="sensei-video.mp4"/><media-source href="sensei-video.ogg"/><media-source href="sensei-video.webm"/><media-track href="sensei-video.vtt" srclang="en"/></video><example><title>title</title></example><simpletable><title>Table title</title><sthead><stentry><p>Header 1</p></stentry><stentry><p>Header 2</p></stentry></sthead><strow><stentry><p>Row 1, Cell 1</p></stentry><stentry><p>Row 1, Cell 2</p></stentry></strow><strow><stentry><p>Row 2, Cell 1</p></stentry><stentry><p>Row 2, Cell 2</p></stentry></strow></simpletable><fig><title>Figure title</title><desc>Figure description</desc><image href="images/image.png"><alt>alt text</alt></image></fig><note type="note"><p>Note content</p></note><section><title>Section title</title><p>Section content</p></section><div><fn id="footnote"/></div></body></topic>`
+<topic id="fullTopic"><title dir="ltr" xml:lang="english" translate="no"><b>bold</b> and <em>emphasized</em> and <i>italic</i> and <ph>Phrase content</ph> and <strong>strong</strong>
+        and <sub>subscript</sub> and <sup>superscipt</sup> and <tt>tele type</tt> and <u>underline</u><image/></title><shortdesc>Short description of the full topic.</shortdesc><prolog props="metadata"><metadata><othermeta name="test" content="test"/></metadata></prolog><body outputclass="outputclass"><p>Paragraph content</p><ul><li><p>Unordered list item</p></li></ul><ol><li><p>Ordered list item</p></li></ol><dl><dlentry><dt>Definition term</dt><dd><p>Definition description</p></dd></dlentry></dl><pre>Preformatted content</pre><audio autoplay="false" controls="true" loop="false" muted="false"><desc>Theme song for the LwDITA podcast</desc><fallback><p>The theme song is not available.</p></fallback><media-source href="theme-song.mp3"/><media-track href="theme-song.vtt" srclang="en"/></audio><video width="400px" height="300px" loop="false" muted="false"><desc>Video about the Sensei Sushi promise.</desc><fallback><image href="video-not-available.png"><alt>This video cannot be displayed.</alt></image></fallback><video-poster href="sensei-video.jpg"/><media-source href="sensei-video.mp4"/><media-source href="sensei-video.ogg"/><media-source href="sensei-video.webm"/><media-track href="sensei-video.vtt" srclang="en"/></video><example><title>title</title></example><simpletable><title>Table title</title><sthead><stentry><p>Header 1</p></stentry><stentry><p>Header 2</p></stentry></sthead><strow><stentry><p>Row 1, Cell 1</p></stentry><stentry><p>Row 1, Cell 2</p></stentry></strow><strow><stentry><p>Row 2, Cell 1</p></stentry><stentry><p>Row 2, Cell 2</p></stentry></strow></simpletable><fig><title>Figure title</title><desc>Figure description</desc><image href="images/image.png"><alt>alt text</alt></image></fig><note type="note"><p>Note content</p></note><section><title>Section title</title><p>Section content</p></section><div><fn id="footnote"/></div></body></topic>`
 
 export const fullAstObject = {
-  xmlDecl: {
-    version: "1.0",
-    encoding: "UTF-8",
-    standalone: undefined,
-  },
   docTypeDecl: {
     name: "topic",
     publicId: "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN",
     systemId: "lw-topic.dtd",
+  },
+  xmlDecl: {
+    version: "1.0",
+    encoding: "UTF-8",
+    standalone: undefined,
   },
   _children: [
     {
@@ -89,11 +87,6 @@ export const fullAstObject = {
             class: undefined,
           },
           _children: [
-            {
-              _props: {
-                content: "\n        ",
-              },
-            },
             {
               _props: {
                 dir: undefined,
@@ -301,11 +294,6 @@ export const fullAstObject = {
                 keyref: undefined,
                 outputclass: undefined,
                 class: undefined,
-              },
-            },
-            {
-              _props: {
-                content: "\n        ",
               },
             },
           ],
@@ -1409,10 +1397,6 @@ export const fullJditaObject = {
           },
           children: [
             {
-              nodeName: "text",
-              content: "\n        ",
-            },
-            {
               nodeName: "b",
               attributes: {
                 dir: undefined,
@@ -1614,10 +1598,6 @@ export const fullJditaObject = {
                 class: undefined,
               },
               children: undefined,
-            },
-            {
-              nodeName: "text",
-              content: "\n        ",
             },
           ],
         },

--- a/packages/lwdita-xdita/test/xdita-serializer.spec.ts
+++ b/packages/lwdita-xdita/test/xdita-serializer.spec.ts
@@ -309,3 +309,152 @@ describe('handles custom xml declaration and doctype', () => {
     expect(actual).equal(expected);
   })
 })
+
+describe('Full round trip with Paragraph', () => {
+  it('should round trip with paragraph', async () => {
+    const { serializer, outStream } = newSerializer(false);
+    const header = '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n'
+    const input = '<topic><title>Hello World</title><body><p>Good\nMorning</p></body></topic>'
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+    // the input and output should be identical
+    const expected =  header + input
+
+    const actual = outStream.getText()
+
+    expect(actual).equal(expected);
+  })
+
+  it('should round trip with paragraph with empty text', async () => {
+    const { serializer, outStream } = newSerializer(false);
+    const header = '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n'
+    const input = '<topic><title>Hello World</title><body><p> </p></body></topic>'
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+    // the paragraph will be serialized as <p/>
+    const expected =  header + '<topic><title>Hello World</title><body><p/></body></topic>'
+
+    const actual = outStream.getText()
+
+    expect(actual).equal(expected);
+  })
+
+  it('should round trip with paragraph with image and indent off', async () => {
+    const { serializer, outStream } = newSerializer(false);
+    const header = '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n'
+    const input = '<topic><title>Hello World</title><body><p><image href="test"><alt>no image</alt></image></p></body></topic>'
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+    // the input and output should be identical
+    const expected =  header + input
+
+    const actual = outStream.getText()
+
+    expect(actual).equal(expected);
+  })
+
+  it('should round trip with paragraph with one image', async () => {
+    const { serializer, outStream } = newSerializer(true);
+    const header = '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n'
+    const input = '<topic><title>Hello World</title><body><p><image href="test"><alt>no image</alt></image></p></body></topic>'
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+    // the input and output should be identical
+    const expected =  header + `<topic>
+    <title>Hello World</title>
+    <body>
+        <p>
+            <image href="test">
+                <alt>no image</alt>
+            </image>
+        </p>
+    </body>
+</topic>\n`
+
+    const actual = outStream.getText()
+
+    expect(actual).equal(expected);
+  })
+
+
+  it('should round trip with paragraph with one image and wrong indentation', async () => {
+    const { serializer, outStream } = newSerializer(true);
+    const header = '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n'
+    const input = `<topic><title>Hello World</title><body><p>
+       <image href="test"><alt>no image</alt></image>    </p></body></topic>`
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+    // the input and output should be identical
+    const expected =  header + `<topic>
+    <title>Hello World</title>
+    <body>
+        <p>
+            <image href="test">
+                <alt>no image</alt>
+            </image>
+        </p>
+    </body>
+</topic>\n`
+
+    const actual = outStream.getText()
+
+    expect(actual).equal(expected);
+  })
+
+
+  it('should round trip with paragraph with more then one image', async () => {
+    const { serializer, outStream } = newSerializer(true);
+    const header = '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n'
+    const input = `<topic><title>Hello World</title><body><p><image href="test"><alt>no image</alt></image><image href="test"><alt>no image</alt></image></p></body></topic>`
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+    // the input and output should be identical
+    const expected =  header + `<topic>
+    <title>Hello World</title>
+    <body>
+        <p>
+            <image href="test">
+                <alt>no image</alt>
+            </image>
+            <image href="test">
+                <alt>no image</alt>
+            </image>
+        </p>
+    </body>
+</topic>\n`
+
+    const actual = outStream.getText()
+
+    expect(actual).equal(expected);
+  })
+
+  it('should round trip with paragraph with more then one image', async () => {
+    const { serializer, outStream } = newSerializer(true);
+    const header = '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE topic PUBLIC "-//OASIS//DTD LIGHTWEIGHT DITA Topic//EN" "lw-topic.dtd">\n'
+    const input = `<topic><title>Hello World</title><body><p>initial text<image href="test"><alt>no image</alt></image>and<image href="test"><alt>no image</alt></image>trailing text</p></body></topic>`
+    const orginalAst = await xditaToAst(input);
+    serializer.serialize(orginalAst);
+
+    // the input and output should be identical
+    const expected =  header + `<topic>
+    <title>Hello World</title>
+    <body>
+        <p>initial text<image href="test">
+                <alt>no image</alt>
+            </image>and<image href="test">
+                <alt>no image</alt>
+            </image>trailing text</p>
+    </body>
+</topic>\n`
+
+    const actual = outStream.getText()
+
+    expect(actual).equal(expected);
+  })
+})


### PR DESCRIPTION
# Motivation
The indentation was wrong for elements that allows mixed content.
![image](https://github.com/user-attachments/assets/e75326f5-1d00-4de6-a083-f2ea630c3655)

# The fix
The serializer will check if an element has no text children, and if so It will indent children as a regulars element, some examples:
1. A `p` tag with one image child:
```xml
<p>
    <image href="test">
        <alt>no image</alt>
    </image>
</p>
```

2. A `p` tag with multiple image children:
```xml
<p>
    <image href="test">
        <alt>no image</alt>
    </image>
    <image href="test">
        <alt>no image</alt>
    </image>
</p>
```

3. A `p` tag with mixed content and images:
```xml
<p>initial text<image href="test">
        <alt>no image</alt>
    </image>and<image href="test">
        <alt>no image</alt>
    </image>trailing text</p>
```

@adamretter I do suggest that (3) become
```xml
<p>initial text<image href="test"><alt>no image</alt></image>and<image href="test"><alt>no image</alt></image>trailing text</p>
```
Check the new added specs in `xdita-serializer.spec.ts` to see full behavior.