### PR TITLE
Update Tsconfig and exclude files to fix TS6059 error

### DIFF
--- a/packages/lwdita-ast/tsconfig.json
+++ b/packages/lwdita-ast/tsconfig.json
@@ -6,6 +6,8 @@
     },
 
     "exclude": [
-      "test/*"
+      "test/**/*",
+      "generated-docs/**/*",
+      "node_modules",
     ]
 }

--- a/packages/lwdita-xdita/tsconfig.json
+++ b/packages/lwdita-xdita/tsconfig.json
@@ -4,9 +4,10 @@
       "rootDir": "src",
       "outDir": "dist",
     },
-
     "exclude": [
-      "test/*",
+      "test/**/*",
+      "generated-docs/**/*",
+      "node_modules",
       "example.ts"
     ]
 }


### PR DESCRIPTION
Update the exclude pattern to
```js
    "exclude": [
      "test/**/*",
      "generated-docs/**/*",
      "node_modules",
    ]
``` 
and explicitly exclude `example.ts` from the build so it won't trigger the TS6059 error
```sh
error TS6059: File 'C:/Users/z/Documents/work/lwdita/packages/lwdita-xdita/example.ts' is not under 'rootDir' 'C:/Users/z/Documents/work/lwdita/packages/lwdita-xdita/src'. 'rootDir' is expected to contain all source files.
```