### PR TITLE
Update tsconfig and eslint to match the Monorepo setup

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -21,6 +21,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 import notice from "eslint-plugin-notice";
 import tsdoc from "eslint-plugin-tsdoc";
+import path from "path";
 
 
 export default defineConfig([
@@ -62,7 +63,10 @@ export default defineConfig([
         }
       ],
       // notice
-      "notice/notice": ["error", { templateFile: "./config/notice.js" }],
+      "notice/notice": [
+        "error", 
+        { templateFile: path.resolve(__dirname, "./config/notice.js") }
+      ],
 
       // tsdoc
       "tsdoc/syntax": "warn"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha",
     "test:watch": "mocha -w",
     "generate-docs": "yarn workspaces foreach --parallel --recursive --from '@evolvedbinary/lwdita-*' run docs",
-    "lint": "yarn workspaces foreach --parallel --recursive --from '@evolvedbinary/lwdita-*' run lint",
+    "lint": "yarn workspaces foreach --recursive --from '@evolvedbinary/lwdita-*' run lint",
     "coverage": "rimraf coverage && nyc yarn mocha",
     "coveralls": "nyc --reporter=text-lcov report | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha",
     "test:watch": "mocha -w",
     "generate-docs": "yarn workspaces foreach --parallel --recursive --from '@evolvedbinary/lwdita-*' run docs",
-    "lint": "eslint",
+    "lint": "yarn workspaces foreach --parallel --recursive --from '@evolvedbinary/lwdita-*' run lint",
     "coverage": "rimraf coverage && nyc yarn mocha",
     "coveralls": "nyc --reporter=text-lcov report | coveralls"
   },

--- a/packages/lwdita-ast/eslint.config.mts
+++ b/packages/lwdita-ast/eslint.config.mts
@@ -1,0 +1,30 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import rootConfig from "../../eslint.config.mjs";
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+
+export default defineConfig([
+  ...rootConfig,
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      globals: { ...globals.browser }
+    }
+  },
+]);

--- a/packages/lwdita-ast/package.json
+++ b/packages/lwdita-ast/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "prepack": "yarn run build",
     "docs": "typedoc --options typedoc.config.mjs --entryPoints src/index.ts --out dist/doc"
   },

--- a/packages/lwdita-ast/package.json
+++ b/packages/lwdita-ast/package.json
@@ -11,7 +11,8 @@
     "build": "tsc",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "prepack": "yarn run build",
-    "docs": "typedoc --options typedoc.config.mjs --entryPoints src/index.ts --out dist/doc"
+    "docs": "typedoc --options typedoc.config.mjs --entryPoints src/index.ts --out dist/doc",
+    "lint": "eslint"
   },
   "keywords": [
     "LwDITA",
@@ -30,6 +31,7 @@
     "url": "https://github.com/evolvedbinary/lwdita/issues"
   },
   "devDependencies": {
+    "eslint": "^9.38.0",
     "rimraf": "^6.1.0",
     "typedoc": "^0.28.14",
     "typescript": "5.9.3"

--- a/packages/lwdita-ast/tsconfig.json
+++ b/packages/lwdita-ast/tsconfig.json
@@ -3,10 +3,9 @@
     "compilerOptions": {
       "rootDir": "src",
       "outDir": "dist",
+      "composite": true,
+      "declaration": true,
+      "declarationMap": true,
     },
-
-    "exclude": [
-      "test/**/*",
-      "node_modules",
-    ]
+    "include": ["src/**/*"]
 }

--- a/packages/lwdita-ast/typedoc.config.mjs
+++ b/packages/lwdita-ast/typedoc.config.mjs
@@ -17,7 +17,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { OptionDefaults } from "typedoc";
 
-/** @type {Partial<import('typedoc').TypeDocOptions>} */
 const config = {
   tsconfig: "./tsconfig.json",
   modifierTags: [...OptionDefaults.modifierTags, "@decorator"],

--- a/packages/lwdita-xdita/eslint.config.mts
+++ b/packages/lwdita-xdita/eslint.config.mts
@@ -1,0 +1,30 @@
+/*!
+Copyright (C) 2020 Evolved Binary
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import rootConfig from "../../eslint.config.mjs";
+import { defineConfig } from "eslint/config";
+import globals from "globals";
+
+export default defineConfig([
+  ...rootConfig,
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      globals: { ...globals.browser }
+    }
+  },
+]);

--- a/packages/lwdita-xdita/package.json
+++ b/packages/lwdita-xdita/package.json
@@ -12,7 +12,8 @@
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "prepack": "yarn run build",
     "docs": "typedoc --options typedoc.config.mjs --entryPoints src/index.ts --out dist/doc",
-    "example": "ts-node ./example.ts"
+    "example": "ts-node ./example.ts",
+    "lint": "eslint"
   },
   "keywords": [
     "LwDITA",
@@ -39,6 +40,7 @@
   ],
   "devDependencies": {
     "@types/node": "^24.10.1",
+    "eslint": "^9.38.0",
     "rimraf": "^6.1.0",
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.14",

--- a/packages/lwdita-xdita/package.json
+++ b/packages/lwdita-xdita/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist tsconfig.tsbuildinfo",
     "prepack": "yarn run build",
     "docs": "typedoc --options typedoc.config.mjs --entryPoints src/index.ts --out dist/doc",
     "example": "ts-node ./example.ts"

--- a/packages/lwdita-xdita/tsconfig.json
+++ b/packages/lwdita-xdita/tsconfig.json
@@ -1,12 +1,19 @@
 {
-    "extends": "../../tsconfig.json",
-    "compilerOptions": {
-      "rootDir": "src",
-      "outDir": "dist",
-    },
-    "exclude": [
-      "test/**/*",
-      "node_modules",
-      "example.ts"
-    ]
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "example.ts"
+  ],
+  "references": [
+    { "path": "../lwdita-ast" }
+  ]
 }

--- a/packages/lwdita-xdita/tsconfig.json
+++ b/packages/lwdita-xdita/tsconfig.json
@@ -10,9 +10,6 @@
   "include": [
     "src/**/*"
   ],
-  "exclude": [
-    "example.ts"
-  ],
   "references": [
     { "path": "../lwdita-ast" }
   ]

--- a/packages/lwdita-xdita/typedoc.config.mjs
+++ b/packages/lwdita-xdita/typedoc.config.mjs
@@ -17,7 +17,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { OptionDefaults } from "typedoc";
 
-/** @type {Partial<import('typedoc').TypeDocOptions>} */
 const config = {
   tsconfig: "./tsconfig.json",
   modifierTags: [...OptionDefaults.modifierTags, "@decorator"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,16 @@
 
   // overrides recommended
   "compilerOptions": {
+    "target": "es6",                          /* Target ECMAScript version 6. */
     "skipLibCheck": false,                    /* Do NOT skip type checking of declaration files. */
     "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     "noEmit": false,                          /* NOTE(AR) just making it explicit that we are using tsc (and not another tool) to emit compiled JavaScript */
     "moduleResolution": "node10",             /* NOTE(AR) just making it explicit that this is the tsc compilation strategy for module resolution that we are currently using */
-    "rootDir": "src",
-    "outDir": "dist",                         /* Redirect output structure to the `dist/` directory. */
   },
+  "references": [
+    { "path": "./packages/lwdita-ast" },
+    { "path": "./packages/lwdita-xdita" },
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
 
   // overrides recommended
   "compilerOptions": {
-    "target": "es6",                          /* Target ECMAScript version 6. */
     "skipLibCheck": false,                    /* Do NOT skip type checking of declaration files. */
     "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -377,6 +377,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@evolvedbinary/lwdita-ast@workspace:packages/lwdita-ast"
   dependencies:
+    eslint: "npm:^9.38.0"
     rimraf: "npm:^6.1.0"
     typedoc: "npm:^0.28.14"
     typescript: "npm:5.9.3"
@@ -390,6 +391,7 @@ __metadata:
     "@evolvedbinary/lwdita-ast": "workspace:^"
     "@rubensworks/saxes": "npm:6.0.1"
     "@types/node": "npm:^24.10.1"
+    eslint: "npm:^9.38.0"
     rimraf: "npm:^6.1.0"
     ts-node: "npm:^10.9.2"
     typedoc: "npm:^0.28.14"
@@ -1742,7 +1744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.39.1":
+"eslint@npm:^9.38.0, eslint@npm:^9.39.1":
   version: 9.39.1
   resolution: "eslint@npm:9.39.1"
   dependencies:


### PR DESCRIPTION
This PR does 2 thing:
1. Add references and clean up `tsconfig`.
2. Split the `eslint` between packages.

