### PR TITLE
Project should emit ES6 compatible Javascript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 
   // overrides recommended
   "compilerOptions": {
+    "target": "es6",                          /* Set the JavaScript language version for emitted JavaScript*/
     "skipLibCheck": false,                    /* Do NOT skip type checking of declaration files. */
     "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */


### PR DESCRIPTION
Right now we are emitting ES7, We can switch to ES6 and gain more support https://caniuse.com/?search=es2016
Also it would match the [prosemirror ](https://github.com/evolvedbinary/prosemirror-lwdita) project config